### PR TITLE
Fixes docker scripts for demo to work properly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,6 @@ GO ?= go
 GOROOT ?= $(shell $(GO) env GOROOT)
 GOPATH ?= $(shell $(GO) env GOPATH)
 GOBIN ?= $(GOPATH)/bin
-GOLINT ?= $(GOBIN)/golint
 GOSEC ?= $(GOBIN)/gosec
 
 GSHBIN ?= gsh
@@ -24,17 +23,16 @@ check-deps:
 
 ## Gets all go test dependencies
 get-test-deps:
-	$(GO) get -u golang.org/x/lint/golint
 	$(GO) install github.com/mattn/goveralls@latest
 
 ## Runs a security static analysis using Gosec
 check-sec:
-	$(GO) get -u github.com/securego/gosec/cmd/gosec
+	$(GO) install github.com/securego/gosec/v2/cmd/gosec@latest
 	$(GOSEC) ./... 2> /dev/null
 
 ## Runs lint
 lint:
-	$(GOLINT) $(shell $(GO) list ./...)
+	$(GO) vet ./...
 
 ## Perfoms all make tests
 test: get-test-deps check-deps lint coverage

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,20 +1,11 @@
-FROM golang:1-alpine3.8 AS build
-ADD  ./ ${GOPATH}/src/github.com/globocom/gsh
-WORKDIR ${GOPATH}/src/github.com/globocom/gsh
-RUN apk add --update git && \
-    go get -u github.com/golang/dep/cmd/dep && \
-    dep ensure -v && \
-    go build -o /tmp/gsh-api ./api && \
-    go build -o /tmp/gsh-agent ./agent
-
 FROM alpine:3.8 AS gsh-api
-COPY --from=build /tmp/gsh-api /usr/local/bin
+ADD ./dist/linux/amd64/ /usr/local/bin
 ADD ./docker/scripts /tmp/scripts
 RUN chmod +x /tmp/scripts/api-run.sh
 CMD ["/tmp/scripts/api-run.sh"]
 
 FROM alpine:3.8 AS gsh-target-machine
-COPY --from=build /tmp/gsh-agent /usr/local/bin
+ADD ./dist/linux/amd64/ /usr/local/bin
 ADD ./docker/scripts /tmp/scripts
 RUN apk add --no-cache openssh && \
     chmod +x /tmp/scripts/target-machine-run.sh

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -10,7 +10,11 @@ COLOR_RED = \033[31m
 PROJECT := GSH
 
 ## Installs a development environment
-install: environment deploy msg
+install: dist environment deploy msg
+
+# Check if dist folder already exists
+dist:
+	if [ ! -d "../dist" ]; then echo "-> Stopping here... you need run 'make release' before!"; exit 1; fi
 
 ## Composes project using docker-compose
 deploy:

--- a/docker/scripts/gsh-realm.json
+++ b/docker/scripts/gsh-realm.json
@@ -446,7 +446,7 @@
     {
       "id": "a09c3e88-2168-47fa-af13-887c663af47f",
       "clientId": "gsh",
-      "rootUrl": "http://localhost:*",
+      "rootUrl": "http://localhost:30000",
       "adminUrl": "http://localhost:*",
       "surrogateAuthRequired": false,
       "enabled": true,

--- a/docker/scripts/target-machine-run.sh
+++ b/docker/scripts/target-machine-run.sh
@@ -3,9 +3,10 @@
 # This script initializes gsh-agent on the target machine.
 #
 
+sed -i s/root:!/"root:*"/g /etc/shadow
 mv /tmp/scripts/ca_host_key.pub /etc/ssh/cas.pub
 echo "TrustedUserCAKeys /etc/ssh/cas.pub" > /etc/ssh/sshd_config
-echo "AuthorizedPrincipalsCommand /usr/local/bin/gsh-agent check-permission --key-id %i --username %u --api http://gsh_api:8000" >> /etc/ssh/sshd_config
+echo "AuthorizedPrincipalsCommand /usr/local/bin/gsh-agent check-permission --serial-number %s --key-id %i --username %u --api http://gsh_api:8000" >> /etc/ssh/sshd_config
 echo "AuthorizedPrincipalsCommandUser $(whoami)" >> /etc/ssh/sshd_config
 
 ssh-keygen -f /etc/ssh/ssh_host_rsa_key -N '' -t rsa


### PR DESCRIPTION
## Context

The demo using docker-compose needs tweaking to work properly. This PR addresses current issues by providing a solution to using the demo.

## Steps to use demo

To start the demo, you need create a builded versions after clonning repo:
```
make release
```

After it, we can run the demo:
```
cd docker
make install
```

To configure gsh-client:
```
../dist/darwin/amd64/gsh target-add local http://localhost:8000 -s
```

Now, you need crate a user with email `admin@example.com`. Please, check that we are using macOS keychain to store credentials.
```
../dist/darwin/amd64/gsh login -s keychain
```

Configure a role to allow the ssh access to docker with gsh-agent (attention, this is a very permissive role):
```
../dist/darwin/amd64/gsh role-add docker -s 172.16.0.0/12 -d 172.16.0.0/12 -u root
../dist/darwin/amd64/gsh role-assign docker admin@example.com
```

Check the gsh-agent docker IP using `docker inspect gsh_target_machine`. After that, change the IPs in the following command to get the SSH call to connect to the target docker.
```
../dist/darwin/amd64/gsh h -d -u root -p 22000 -s 172.23.0.1 172.23.0.5   
```

The command will look like:
```
ssh -i /Users/manoel.junior/.gsh/certs/local/RDaaz8s9z4oU5r2Iocqy4W1SSkBPeq9l -i /Users/manoel.junior/.gsh/certs/local/RDaaz8s9z4oU5r2Iocqy4W1SSkBPeq9l-cert.pub -l root -p 22000 172.20.0.5
```

Remove the destination IP at the end and put it as localhost since docker is forwarding the port to your computer.
```
ssh -i /Users/manoel.junior/.gsh/certs/local/RDaaz8s9z4oU5r2Iocqy4W1SSkBPeq9l -i /Users/manoel.junior/.gsh/certs/local/RDaaz8s9z4oU5r2Iocqy4W1SSkBPeq9l-cert.pub -l root -p 22000 localhost 
```


